### PR TITLE
【优化体验】自动跟随系统主题色（调用MDUI原生方法）

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -37,7 +37,7 @@ $accentColor = $this->options->accentColor;
   <?php fontFamily();$this->header('commentReply='); bgUrl(); otherCss();?>
 </head>
 
-<body class="mdui-theme-primary-<?php echo $primaryColor; ?> mdui-theme-accent-<?php echo $accentColor; ?>" id="body">
+<body class="mdui-theme-primary-<?php echo $primaryColor; ?> mdui-theme-accent-<?php echo $accentColor; ?> mdui-theme-layout-auto" id="body">
   <div class="background"></div>
   <div class="mdui-appbar mdui-shadow-0 mdui-appbar-fixed mdui-appbar-scroll-hide">
     <div class="mdui-toolbar">


### PR DESCRIPTION
Q：这个提交更新了什么？
A：本次提交可以让主题自动跟随系统的主题色。
Q：和js实现的自动跟随系统主题色有什么不同？
A：这个实现是使用MDUI原生的CSS支持，可以避免在首次载入网页时一闪而过的亮色主题。优化用户体验。
MDUI文档：https://www.mdui.org/docs/color#theme-layout