### PR TITLE
🔨 修复顶部跨设备阅读出现预期外的滚动条

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -79,7 +79,7 @@ $accentColor = $this->options->accentColor;
         <button class="mdui-textfield-close mdui-btn mdui-btn-icon"><i class="mdui-icon material-icons">close</i></button>
       </div>
       <button class="mdui-btn mdui-btn-icon qrcode" mdui-menu="{target: '#qrcode'}" mdui-tooltip="{content: '跨设备阅读'}"><i class="mdui-icon material-icons">devices</i></button>
-      <div class="mdui-menu" id="qrcode" style="width: 170px;height: 170px;transform-origin: 100% 0px; position: fixed; text-align:center;"><div style='margin-top: 63px;' class="mdui-spinner mdui-spinner-colorful"></div></div>
+      <div class="mdui-menu" id="qrcode" style="overflow-y: hidden;width: 170px;height: 170px;transform-origin: 100% 0px; position: fixed; text-align:center;"><div style='margin-top: 63px;' class="mdui-spinner mdui-spinner-colorful"></div></div>
       <button onclick="brightness()" id="brightness" class="mdui-textfield-close mdui-btn mdui-btn-icon"><i class="mdui-icon material-icons">brightness_5</i></button>
       <button onclick="tocBotton()" id="tocBotton" class="mdui-textfield-close mdui-btn mdui-btn-icon"><i class="mdui-icon material-icons">bookmark</i></button>
     </div>


### PR DESCRIPTION
## 现况描述

![image](https://github.com/bhaoo/Cuckoo/assets/30862240/c8aa7175-1a3f-4745-8c30-a716d12a3b9b)

不管二维码是否超出flyout, 都会显示这个滚动条

## 修改后

![image](https://github.com/bhaoo/Cuckoo/assets/30862240/4de5217c-05b4-4254-ab56-f13dba4a1131)
