### PR TITLE
delete: Staticfile & BootCDN

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -180,7 +180,16 @@ function staticFiles($content, $type = 0, $isExternal = 0) {
   }
   switch($setting){
     case 'jsdelivr':
+      $output = 'https://cdn.jsdelivr.net/gh/Bhaoo/Cuckoo@'.THEME_VERSION.'/assets/'.$content;
+      break;
+    case 'fastly':
+      $output = 'https://fastly.jsdelivr.net/gh/Bhaoo/Cuckoo@'.THEME_VERSION.'/assets/'.$content;
+      break;
+    case 'gcore':
       $output = 'https://gcore.jsdelivr.net/gh/Bhaoo/Cuckoo@'.THEME_VERSION.'/assets/'.$content;
+      break;
+    case 'jsdmirror':
+      $output = 'https://cdn.jsdmirror.com/gh/Bhaoo/Cuckoo@'.THEME_VERSION.'/assets/'.$content;
       break;
     case 'cdn':
       $output = Helper::options()->staticCdn.'/'.$content;
@@ -188,11 +197,11 @@ function staticFiles($content, $type = 0, $isExternal = 0) {
     case 'cdnjs':
       $output = 'https://cdnjs.cloudflare.com/ajax/libs/Cuckoo/'.THEME_VERSION.'/'.$content;
       break;
-    case 'staticfile':
-      $output = 'https://cdn.staticfile.org/Cuckoo/'.THEME_VERSION.'/'.$content;
+    case 'snrat':
+      $output = 'https://cdnjs.snrat.com/ajax/libs/Cuckoo/'.THEME_VERSION.'/'.$content;
       break;
-    case 'bootcdn':
-      $output = 'https://cdn.bootcdn.net/ajax/libs/Cuckoo/'.THEME_VERSION.'/'.$content;
+    case 'zstatic':
+      $output = 'https://s4.zstatic.net/ajax/libs/Cuckoo/'.THEME_VERSION.'/'.$content;
       break;
     case 'baomitu':
       $output = 'https://lib.baomitu.com/Cuckoo/'.THEME_VERSION.'/'.$content;

--- a/includes/setting.php
+++ b/includes/setting.php
@@ -164,9 +164,12 @@ function themeConfig($form) {
         <?php echo $config->select('staticFiles',
             ['local'       => '本地',
               'jsdelivr'   => 'JsDelivr',
+              'fastly'   => 'Fastly',
+              'gcore'   => 'Gcore',
+              'jsdmirror'   => 'JsdMirror',
               'cdnjs'      => 'cdnjs',
-              'staticfile' => 'Staticfile',
-              'bootcdn'    => 'Bootcdn',
+              'snrat' => 'snrat',
+              'zstatic'    => 'zstatic',
               'baomitu'    => 'Baomitu',
               'cdn'        => '自定义 CDN'
             ], '静态文件源', '推荐选择 “JsDelivr源”', 'local').


### PR DESCRIPTION
由于Staticfile和BootCDN此前被供应链投毒，导致在使用了某些浏览器广告拦截插件的情况下会阻止文件加载，此PR移除了这两个CDN